### PR TITLE
URLの末尾にパラメーターが付いた場合にも対応するように修正

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -52,7 +52,7 @@ export const fetchShopList = async () => {
 		const a = li.getElementsByTagName('a')[0]
 		const name = a.innerHTML.replace(/\s+/g, '').replace(/(<([^>]+)>)/gi, '') // 空白文字の削除&<span>タグの削除
 		const href = a.href
-		const id = href.match(/(\d+).html$/)[1]
+		const id = href.match(/(\d+).html/)[1]
 		shopList.push({
 			name: name,
 			href: href,


### PR DESCRIPTION
各店舗のページへのリンクの末尾に`?takeout=`がつくようになったことへの対応

これまでは、
`https://hidakaya.hiday.co.jp/hits/ja/shop/99/detail/244.html`

というようなURLだったが、先週未明に
`https://hidakaya.hiday.co.jp/hits/ja/shop/99/detail/244.html?takeout=`
のようにパラメータがつくようになった。